### PR TITLE
Add support for maven type mapping

### DIFF
--- a/src/main/java/com/redhat/rcm/offliner/Main.java
+++ b/src/main/java/com/redhat/rcm/offliner/Main.java
@@ -408,7 +408,7 @@ public class Main
 
         artifactListReaders = new ArrayList<>( 2 );
         artifactListReaders.add( new PlaintextArtifactListReader( baseUrl ) );
-        artifactListReaders.add( new PomArtifactListReader( opts.getSettingsXml(), creds ) );
+        artifactListReaders.add( new PomArtifactListReader( opts.getSettingsXml(), opts.getTypeMapping(), creds ) );
     }
 
 }

--- a/src/main/java/com/redhat/rcm/offliner/Options.java
+++ b/src/main/java/com/redhat/rcm/offliner/Options.java
@@ -27,6 +27,8 @@ import org.kohsuke.args4j.ParserProperties;
 public class Options
 {
 
+    public static final String DEFAULT_TYPE_MAPPING = "test-jar=jar:tests;ejb=jar;ejb-client=jar:client;maven-plugin=jar;java-source=jar:sources;javadoc=jar:javadoc";
+
     private static final int DEFAULT_CONNECTIONS = 200;
 
     public static final String DEFAULT_REPO_URL = "https://maven.repository.redhat.com/ga/all/";
@@ -61,6 +63,11 @@ public class Options
 
     @Option( name = "-s", aliases = { "--mavensettings" }, metaVar = "FILE", usage = "Path to settings.xml used when a pom is used as the source file" )
     private File settingsXml;
+
+    @Option( name = "-s", aliases = { "--maventypemapping" }, metaVar = "MAPPING", usage = "List of mapping where key is "
+        + "type and value is file extension with or without classifier separated by colon. List elements are separated by "
+        + "semicolons." )
+    private String typeMapping = DEFAULT_TYPE_MAPPING;
 
     @Option( name = "-h", aliases = { "--help" }, help = true, usage = "Print this help screen and exit" )
     private boolean help;
@@ -211,6 +218,16 @@ public class Options
     public void setSettingsXml( final File settingsXml )
     {
         this.settingsXml = settingsXml;
+    }
+
+    public String getTypeMapping()
+    {
+        return typeMapping;
+    }
+
+    public void setTypeMapping( final String typeMapping )
+    {
+        this.typeMapping = typeMapping;
     }
 
 }

--- a/src/test/java/com/redhat/rcm/offliner/PomArtifactListReaderTest.java
+++ b/src/test/java/com/redhat/rcm/offliner/PomArtifactListReaderTest.java
@@ -79,7 +79,7 @@ public class PomArtifactListReaderTest
     @Test
     public void readPathsDependencies() throws Exception
     {
-        PomArtifactListReader artifactListReader = new PomArtifactListReader( null, new BasicCredentialsProvider() );
+        PomArtifactListReader artifactListReader = getDefaultListReader();
 
         ArtifactList artList = artifactListReader.readPaths( getFile( "repo.pom" ) );
 
@@ -100,7 +100,7 @@ public class PomArtifactListReaderTest
     @Test
     public void readPathsPomForJar() throws Exception
     {
-        PomArtifactListReader artifactListReader = new PomArtifactListReader( null, new BasicCredentialsProvider() );
+        PomArtifactListReader artifactListReader = getDefaultListReader();
 
         ArtifactList artList = artifactListReader.readPaths( getFile( "repo.pom" ) );
 
@@ -114,7 +114,7 @@ public class PomArtifactListReaderTest
     @Ignore
     public void readPathsParent() throws Exception
     {
-        PomArtifactListReader artifactListReader = new PomArtifactListReader( null, new BasicCredentialsProvider() );
+        PomArtifactListReader artifactListReader = getDefaultListReader();
 
         ArtifactList artList = artifactListReader.readPaths( getFile( "repo.pom" ) );
 
@@ -128,7 +128,7 @@ public class PomArtifactListReaderTest
     @Ignore
     public void readPathsImportedBoms() throws Exception
     {
-        PomArtifactListReader artifactListReader = new PomArtifactListReader( null, new BasicCredentialsProvider() );
+        PomArtifactListReader artifactListReader = getDefaultListReader();
 
         ArtifactList artList = artifactListReader.readPaths( getFile( "repo.pom" ) );
 
@@ -143,7 +143,7 @@ public class PomArtifactListReaderTest
     @Test
     public void readPathsPlugins() throws Exception
     {
-        PomArtifactListReader artifactListReader = new PomArtifactListReader( null, new BasicCredentialsProvider() );
+        PomArtifactListReader artifactListReader = getDefaultListReader();
 
         ArtifactList artList = artifactListReader.readPaths( getFile( "repo.pom" ) );
 
@@ -158,7 +158,7 @@ public class PomArtifactListReaderTest
     @Test
     public void readPathsRepositories() throws Exception
     {
-        PomArtifactListReader artifactListReader = new PomArtifactListReader( null, new BasicCredentialsProvider() );
+        PomArtifactListReader artifactListReader = getDefaultListReader();
 
         ArtifactList artList = artifactListReader.readPaths( getFile( "repo.pom" ) );
 
@@ -174,6 +174,7 @@ public class PomArtifactListReaderTest
     public void readPathsProcessMirror() throws Exception
     {
         PomArtifactListReader artifactListReader = new PomArtifactListReader( getFile( "settings.xml" ),
+                                                                              Options.DEFAULT_TYPE_MAPPING,
                                                                               new BasicCredentialsProvider() );
 
         ArtifactList artList = artifactListReader.readPaths( getFile( "repo.pom" ) );
@@ -190,13 +191,30 @@ public class PomArtifactListReaderTest
     public void readPathsAddRepositoryCredentials() throws Exception
     {
         BasicCredentialsProvider creds = new BasicCredentialsProvider();
-        PomArtifactListReader artifactListReader = new PomArtifactListReader( getFile( "settings.xml" ), creds );
+        PomArtifactListReader artifactListReader = new PomArtifactListReader( getFile( "settings.xml" ),
+                                                                              Options.DEFAULT_TYPE_MAPPING, creds );
 
         // call to invoke processing of settings.xml, but the result is not needed
         artifactListReader.readPaths( getFile( "repo.pom" ) );
 
         Credentials credentials = creds.getCredentials( new AuthScope( "mirror.jboss.org", 80, null, "http" ) );
         assertNotNull( "Credentials for http://mirror.jboss.org/ not loaded", credentials );
+    }
+
+    /**
+     * Checks if type of a dependency is mapped correctly, if its mapping to extension-classifier is defined.
+     */
+    @Test
+    public void readPathsMapType() throws Exception
+    {
+        PomArtifactListReader artifactListReader = getDefaultListReader();
+
+        ArtifactList artList = artifactListReader.readPaths( getFile( "repo.pom" ) );
+
+        List<String> paths = artList.getPaths();
+        checkPath( paths, "org/apache/maven/plugins/maven-dependency-plguin/2.9/maven-dependency-plguin-2.9.pom" );
+        checkPath( paths, "org/apache/maven/plugins/maven-dependency-plguin/2.9/maven-dependency-plguin-2.9.jar" );
+        checkPath( paths, "org/apache/ant/ant/1.8.0/ant-1.8.0-tests.jar" );
     }
 
 
@@ -226,6 +244,11 @@ public class PomArtifactListReaderTest
         {
             assertFalse( "Additional " + subject + " " + needle + " was found in the result", heap.contains( needle ) );
         }
+    }
+
+    private PomArtifactListReader getDefaultListReader()
+    {
+        return new PomArtifactListReader( null, Options.DEFAULT_TYPE_MAPPING, new BasicCredentialsProvider() );
     }
 
 }

--- a/src/test/resources/repo.pom
+++ b/src/test/resources/repo.pom
@@ -82,6 +82,18 @@
       <classifier>ivy</classifier>
       <type>xml</type>
     </dependency>
+    <dependency>
+      <groupId>org.apache.maven.plugins</groupId>
+      <artifactId>maven-dependency-plguin</artifactId>
+      <version>2.9</version>
+      <type>maven-plugin</type>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.ant</groupId>
+      <artifactId>ant</artifactId>
+      <version>1.8.0</version>
+      <type>test-jar</type>
+    </dependency>
   </dependencies>
 
   <repositories>


### PR DESCRIPTION
The artifact type is not always the file extension to use. Sometimes the
type also declares a classifier, so there is a mapping needed.

Default value is the mapping of Maven 3.3.3, but can be overriden on
command-line.