### PR TITLE
#23: Added test scope to org.commonjava.util:http-testserver dependency.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -123,6 +123,7 @@
       <groupId>org.commonjava.util</groupId>
       <artifactId>http-testserver</artifactId>
       <version>1.1</version>
+      <scope>test</scope>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
By adding a 'test' scope to the org.commonjava.util:http-testserver dependency, it is not added to the offliner jar and and the debug-level logging is not activated.