### PR TITLE
Fixed bug where repositories in POM files were not being handled.

### DIFF
--- a/src/main/java/com/redhat/red/offliner/Main.java
+++ b/src/main/java/com/redhat/red/offliner/Main.java
@@ -58,13 +58,7 @@ import java.io.PrintWriter;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.file.Paths;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
@@ -102,6 +96,8 @@ public class Main
     private List<ArtifactListReader> artifactListReaders;
 
     private List<String> baseUrls;
+
+    private final static List<String> DEFAULT_URLS = Arrays.asList( Options.DEFAULT_REPO_URL, Options.CENTRAL_REPO_URL  );
 
     public Main( final Options opts )
             throws MalformedURLException
@@ -285,15 +281,9 @@ public class Main
             if ( baseUrls == null || baseUrls.isEmpty() )
             {
                 baseUrls = artifactList.getRepositoryUrls();
-                if ( baseUrls == null )
+                if ( baseUrls == null || baseUrls.isEmpty() )
                 {
-                    baseUrls = new ArrayList<>();
-                }
-
-                if ( baseUrls.isEmpty() )
-                {
-                    baseUrls.add( Options.DEFAULT_REPO_URL );
-                    baseUrls.add( Options.CENTRAL_REPO_URL );
+                    baseUrls = DEFAULT_URLS;
                 }
             }
 
@@ -547,22 +537,18 @@ public class Main
             baseUrls = new ArrayList<>();
         }
 
-        if ( baseUrls.isEmpty() )
-        {
-            baseUrls.add( Options.DEFAULT_REPO_URL );
-            baseUrls.add( Options.CENTRAL_REPO_URL );
-        }
+        List<String> repoUrls = ( baseUrls.isEmpty() ? DEFAULT_URLS : baseUrls );
 
-        System.out.println( "Planning download from:\n  " + StringUtils.join( baseUrls, "\n  " ) );
+        System.out.println( "Planning download from:\n  " + StringUtils.join( repoUrls, "\n  " ) );
 
-        for ( String baseUrl : baseUrls )
+        for ( String repoUrl : repoUrls )
         {
-            if ( baseUrl != null )
+            if ( repoUrl != null )
             {
                 final String user = opts.getUser();
                 if ( user != null )
                 {
-                    final URL u = new URL( baseUrl );
+                    final URL u = new URL( repoUrl );
                     final AuthScope as = new AuthScope( u.getHost(), UrlUtils.getPort( u ) );
 
                     creds.setCredentials( as, new UsernamePasswordCredentials( user, opts.getPassword() ) );

--- a/src/test/java/com/redhat/red/offliner/ftest/SinglePOMRepoDownloadFTest.java
+++ b/src/test/java/com/redhat/red/offliner/ftest/SinglePOMRepoDownloadFTest.java
@@ -1,0 +1,87 @@
+package com.redhat.red.offliner.ftest;
+
+import com.redhat.red.offliner.Main;
+import com.redhat.red.offliner.Options;
+import com.redhat.red.offliner.ftest.fixture.TestRepositoryServer;
+import org.apache.commons.io.FileUtils;
+import org.apache.maven.model.Dependency;
+import org.apache.maven.model.Model;
+import org.apache.maven.model.Repository;
+import org.junit.Test;
+
+import java.io.File;
+import java.util.Collections;
+
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Create a one-dependency Maven POM containing one repository to test that the artifact can be downloaded from that
+ * repository.
+ *
+ * Created by dcoleman on 02/07/2016.
+ */
+public class SinglePOMRepoDownloadFTest extends AbstractOfflinerFunctionalTest
+{
+    /**
+     * In general, we should only have one test method per functional test. This allows for the best parallelism when we
+     * execute the tests, especially if the setup takes some time.
+     *
+     * @throws Exception In case anything (anything at all) goes wrong!
+     */
+    @Test
+    public void run()
+        throws Exception
+    {
+        // We only need one repo server.
+        TestRepositoryServer server = newRepositoryServer();
+
+        // Generate some test content
+        byte[] content = contentGenerator.newBinaryContent( 1024 );
+
+        Dependency dep = contentGenerator.newDependency();
+        Model pom = contentGenerator.newPom();
+        pom.addDependency( dep );
+
+        // Add a repository to the pom
+        Repository repo = contentGenerator.newRepository( "Test Repo", server.getBaseUri() );
+        pom.addRepository( repo );
+
+        String path = contentGenerator.pathOf( dep );
+
+        // Register the generated content by writing it to the path within the repo server's dir structure.
+        // This way when the path is requested it can be downloaded instead of returning a 404.
+        server.registerContent( path, content );
+
+        // All deps imply an accompanying POM file when using the POM artifact list reader, so we have to register one of these too.
+        Model pomDep = contentGenerator.newPomFor( dep );
+        String pomPath = contentGenerator.pathOf( pomDep );
+
+        server.registerContent( pomPath, contentGenerator.pomToString( pomDep ));
+
+        // Write the POM file we'll use as input
+        File pomFile = temporaryFolder.newFile( getClass().getSimpleName() + ".pom" );
+
+        FileUtils.write( pomFile, contentGenerator.pomToString( pom ));
+
+        Options opts = new Options();
+
+        // Capture the downloads here so we can verify the content.
+        File downloads = temporaryFolder.newFolder();
+
+        opts.setDownloads( downloads );
+        opts.setLocations( Collections.singletonList( pomFile.getAbsolutePath() ) );
+
+        // run `new Main(opts).run()` and return the Main instance so we can query it for errors, etc.
+        Main finishedMain = run( opts );
+
+        assertThat( "Wrong number of downloads logged. Should have been 2 (declared jar + its corresponding POM).",
+                    finishedMain.getDownloaded(), equalTo ( 2 ) );
+        assertThat( "Errors should be empty!", finishedMain.getErrors().isEmpty(), equalTo( true ) );
+
+        File downloaded = new File( downloads, path );
+        assertThat( "File: " + path + " doesn't seem to be downloaded!", downloaded.exists(), equalTo( true ) );
+        assertThat( "Downloaded File: " + path + " contains wrong content!",
+                    FileUtils.readFileToByteArray( downloaded ), equalTo( content ) );
+    }
+}

--- a/src/test/java/com/redhat/red/offliner/ftest/fixture/TestContentGenerator.java
+++ b/src/test/java/com/redhat/red/offliner/ftest/fixture/TestContentGenerator.java
@@ -20,9 +20,7 @@ import com.redhat.red.offliner.folo.TrackedContentEntryDTO;
 import com.redhat.red.offliner.util.UrlUtils;
 import com.redhat.red.offliner.alist.PlaintextArtifactListReader;
 import org.apache.commons.io.IOUtils;
-import org.apache.maven.model.Dependency;
-import org.apache.maven.model.Model;
-import org.apache.maven.model.Parent;
+import org.apache.maven.model.*;
 import org.apache.maven.model.io.xpp3.MavenXpp3Writer;
 
 import java.io.IOException;
@@ -173,6 +171,25 @@ public class TestContentGenerator
     public Dependency newDependency( String type, String scope )
     {
         return newDependency( type, null, scope );
+    }
+
+    public Repository newRepository( String id, String url )
+    {
+        Repository repo = new Repository();
+        repo.setId( id );
+        repo.setUrl( url );
+
+        RepositoryPolicy releasesPolicy = new RepositoryPolicy();
+        RepositoryPolicy snapshotsPolicy = new RepositoryPolicy();
+
+        releasesPolicy.setEnabled( true );
+        snapshotsPolicy.setEnabled( true );
+
+        repo.setReleases( releasesPolicy );
+        repo.setSnapshots( snapshotsPolicy );
+
+        return repo;
+
     }
 
     public TrackedContentEntryDTO newRemoteContentEntry( StoreKey key, String type, String originBaseUri, byte[] content )


### PR DESCRIPTION
The repository URLs were not being read from the artifact list as the baseURLs list had already been populated with the default set of repositories. I factored those out into a separate list to distinguish between urls entered on the command line and the default set, and only read from the artifact list if the command line option was empty. 

I also added a test case for this scenario.