### PR TITLE
Fix slowness implied by FilterOutputStream writing 1 byte at a time + digest per block

### DIFF
--- a/src/main/java/com/redhat/red/offliner/ChecksumOutputStream.java
+++ b/src/main/java/com/redhat/red/offliner/ChecksumOutputStream.java
@@ -16,12 +16,10 @@
 package com.redhat.red.offliner;
 
 import org.apache.commons.codec.binary.Hex;
-import org.apache.commons.io.IOUtils;
 
 import java.io.FilterOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
-import java.io.PrintStream;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 
@@ -41,11 +39,12 @@ public final class ChecksumOutputStream
     }
 
     @Override
-    public void write( int b )
-            throws IOException
-    {
-        super.write( b );
-        this.digest.update( (byte) b );
+    public void write(byte b[], int off, int len) throws IOException {
+        if ((off | len | (b.length - (len + off)) | (off + len)) < 0) {
+            throw new IndexOutOfBoundsException();
+        }
+        out.write(b, off, len);
+        digest.update(b, off, len);
     }
 
     public String getChecksum()


### PR DESCRIPTION
That relates to issue: Fix performance of checksum computation #42
I am observing a huge slowness caused by writing a byte at a time.
- digest.update per block.
- write the block to wrapped output.
