### PR TITLE
Ban log4j from dependency tree

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -162,6 +162,16 @@
       <groupId>io.honeycomb.beeline</groupId>
       <artifactId>beeline-spring-boot-starter</artifactId>
       <version>1.5.0</version>
+      <exclusions>
+        <exclusion>
+           <groupId>org.apache.logging.log4j</groupId>
+           <artifactId>log4j-to-slf4j</artifactId>
+        </exclusion>
+         <exclusion>
+           <groupId>org.apache.logging.log4j</groupId>
+           <artifactId>log4j-api</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
I don't think offliner is affected because the dependency tree only shows log4j-api and log4j-to-slf4j and not log4j-core, but I think banning it and not getting hit by a security scanner might be a good idea.

[INFO]    |  |  +- org.springframework.boot:spring-boot-starter-logging:jar:2.1.1.RELEASE:compile
[INFO]    |  |  |  +- org.apache.logging.log4j:log4j-to-slf4j:jar:2.11.1:compile
[INFO]    |  |  |  |  \- org.apache.logging.log4j:log4j-api:jar:2.11.1:compile
[INFO]    |  |  |  \- org.slf4j:jul-to-slf4j:jar:1.7.25:compile
