### PR TITLE
Update atlas version to 1.1.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
     <dependency>
       <groupId>org.commonjava.atlas</groupId>
       <artifactId>atlas-identities</artifactId>
-      <version>1.1.2</version>
+      <version>1.1.3</version>
     </dependency>
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>


### PR DESCRIPTION
rnetuka reports when building offliner, mvn complains:

`[ERROR] Failed to execute goal on project offliner: Could not resolve dependencies for project com.redhat.red.offliner:offliner:jar:2.2-SNAPSHOT: Failed to collect dependencies at org.commonjava.atlas:atlas-identities:jar:1.1.2: Failed to read artifact descriptor for org.commonjava.atlas:atlas-identities:jar:1.1.2: Could not find artifact org.commonjava.boms:web-commons-bom:pom:27-SNAPSHOT in qe (http://nexus.fuse-qe.eng.rdu2.redhat.com/repository/fuse-all) -> [Help 1]`

This should be due to atlas 1.1.2 released with a SNAPSHOT version of web commons bom.
Update atlas to 1.1.3 to avoid this problem.